### PR TITLE
Fix user's vote not being visible

### DIFF
--- a/PollsAppBlazor.Client/Pages/Polls/Poll.razor
+++ b/PollsAppBlazor.Client/Pages/Polls/Poll.razor
@@ -180,10 +180,6 @@ else
 		try
 		{
 			var client = HttpClientFactory.CreateClient(HttpClientName.AuthApiClientName);
-			// Get poll details
-			poll = (await client.GetFromJsonAsync<PollViewDto>($"/api/polls/{pollId}"))!;
-			selectedOptionId = poll.VotedOptionId;
-			isInFavorites = poll.IsInFavorites;
 
 			// Try to get options with votes
 			var optionsResponse = await client.GetAsync($"/api/polls/{pollId}/options");
@@ -197,6 +193,11 @@ else
 				canViewResults = false;
 				optionsWithVotes = [];
 			}
+
+			// Get poll details
+			poll = (await client.GetFromJsonAsync<PollViewDto>($"/api/polls/{pollId}"))!;
+			selectedOptionId = poll.VotedOptionId;
+			isInFavorites = poll.IsInFavorites;
 
 			// Determine whether user can edit the poll
 			canEdit = null;


### PR DESCRIPTION
Fixed an issue where `/api/polls/{pollId}` did not return `votedOptionId` due to an outdated access token. The fix ensures that calling `/api/polls/{pollId}/options` (which requires a valid token) occurs first, automatically refreshing the token before the poll request.